### PR TITLE
refactor!: Use scrypt for password hashing + finish CLI adduser action

### DIFF
--- a/packages/trackx-api/src/types.ts
+++ b/packages/trackx-api/src/types.ts
@@ -8,11 +8,11 @@ export interface TrackXAPIConfig {
    * User accounts.
    *
    * Emails are case-insensitive at login but MUST BE lowercase here. Generate
-   * a user salt and password hash with the CLI tool. For more details run the
-   * CLI with `trackx adduser --help`.
+   * a user password hash with the CLI tool. For more details run the CLI tool
+   * command `trackx adduser --help`.
    */
   readonly USERS: {
-    readonly [email: string]: readonly [salt: string, passwordHash: string];
+    readonly [email: string]: string;
   };
 
   /**

--- a/packages/trackx-api/trackx.config.js
+++ b/packages/trackx-api/trackx.config.js
@@ -7,11 +7,10 @@ if (!process.env.NODE_ENV || process.env.NODE_ENV === 'production') {
 /** @type {import('./src/types').TrackXAPIConfig} */
 module.exports = {
   USERS: {
-    // email = dev@user + password = development
-    'dev@user': [
-      'zZ1KP0fb',
-      'JpbCaPKt2MPKtWJKjstbdhVtW47iWzpXTtDC6/0sbtOB5wsvacfe+kixyOwXpdZR41chslk2KtPyEUTz2XrWZw==',
-    ],
+    // email = dev@user
+    // password = development
+    'dev@user':
+      'Q9hepNsrx4hKD9IkaAEssw==:pt3AEhfEzXUVSq+a2imNpFEEvERr6uLabxGtUqyiq5krNZ050Bl1fXmsi3UGGOxj6sgwEouO4Agw7L+wyw5fJA==',
   },
 
   ROOT_DIR: __dirname,

--- a/packages/trackx-cli/src/utils.ts
+++ b/packages/trackx-cli/src/utils.ts
@@ -2,6 +2,7 @@ import {
   blue, bold, dim, red, yellow,
 } from 'kleur/colors';
 import path from 'path';
+import { createInterface } from 'readline';
 import type { TrackXAPIConfig } from '../../trackx-api/src/types';
 
 export const logger = {
@@ -159,4 +160,38 @@ export function getConfig(
       ? path.resolve(rootDir, rawConfig.DB_INIT_SQL_PATH)
       : undefined,
   };
+}
+
+/** Read user input from stdin */
+export function read(prompt: string, mask?: boolean): Promise<string> {
+  return new Promise((resolve) => {
+    const output = process.stdout;
+    const rl = createInterface({
+      input: process.stdin,
+      output,
+      historySize: 0,
+    });
+
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+
+    if (mask) {
+      // @ts-expect-error - Private internal API (undocumented)
+      // eslint-disable-next-line no-underscore-dangle
+      rl._writeToOutput = (char: string) => {
+        output.write(['\n', '\r\n', '\r'].includes(char) ? char : '*');
+      };
+    }
+  });
+}
+
+export function validEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export function containsControlChar(str: string): boolean {
+  // eslint-disable-next-line no-control-regex
+  return /[\u0000-\u001F\u007F]/.test(str);
 }


### PR DESCRIPTION
- Replace basic salted sha512 hash with an scrypt based one. `scrypt` was chosen because it's available natively in node.
- Protect against [timing attacks](https://en.wikipedia.org/wiki/Timing_attack).
- `@trackx/cli`: Finish `adduser` command; input validation, error handling, and feedback text. 