### PR TITLE
fix(trackx-dash): Use rel="noopener" on links for better security

### DIFF
--- a/packages/trackx-dash/src/components/Footer.tsx
+++ b/packages/trackx-dash/src/components/Footer.tsx
@@ -8,7 +8,7 @@ export const Footer: Component = () => (
       href="https://maxmilton.com"
       class="normal muted"
       target="_blank"
-      rel="noreferrer"
+      rel="noopener"
     >
       Max Milton
     </a>{' '}
@@ -16,7 +16,7 @@ export const Footer: Component = () => (
     <a
       href="https://github.com/maxmilton/trackx/issues"
       target="_blank"
-      rel="noreferrer"
+      rel="noopener"
     >
       report bug
     </a>

--- a/packages/trackx-dash/src/pages/projects/[name]/install.tsx
+++ b/packages/trackx-dash/src/pages/projects/[name]/install.tsx
@@ -69,7 +69,7 @@ const ProjectInstallPage: RouteComponent = (props) => {
                 <a
                   href="https://maxmilton.github.io/trackx/"
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener"
                 >
                   see the trackx documentation
                 </a>
@@ -128,6 +128,7 @@ export const { sendEvent } = trackx;`}
                     <a
                       href={`${config.DOCS_URL}/#/client/tips.md#build-process`}
                       target="_blank"
+                      rel="noopener"
                     >
                       docs for build process tips
                     </a>
@@ -192,6 +193,7 @@ trackx.setup('${config.REPORT_API_BASE_URL}/${projectData.key}');`}
                 <a
                   href={`${config.DOCS_URL}/#/client/overview.md#feature-comparison`}
                   target="_blank"
+                  rel="noopener"
                 >
                   docs for client features comparison
                 </a>{' '}
@@ -423,6 +425,7 @@ Header set Content-Security-Policy "default-src 'self' ${apiOriginUri};${
                     <a
                       href={`${config.DOCS_URL}/#/client/browser-reports.md`}
                       target="_blank"
+                      rel="noopener"
                     >
                       See the docs page
                     </a>{' '}

--- a/packages/trackx-login/build.mjs
+++ b/packages/trackx-login/build.mjs
@@ -93,10 +93,10 @@ function makeHTML(jsPath, cssPath) {
     </div>
     <button id=submit class="button button-primary ph4" type=submit>Sign in</button>
     <div>
-      Forgot your password? <a href="${config.DOCS_URL}/#/guides/using-the-dash.md#login">Get help signing in</a>
+      Forgot your password? <a href="${config.DOCS_URL}/#/guides/using-the-dash.md#login" rel=noopener>Get help signing in</a>
     </div>
   </form>
-  <footer>© <a href=https://maxmilton.com class="normal muted" rel=noreferrer>Max Milton</a> ・ ${release} ・ <a href=https://github.com/maxmilton/trackx/issues rel=noreferrer>report bug</a></footer>
+  <footer>© <a href=https://maxmilton.com class="normal muted" rel=noopener>Max Milton</a> ・ ${release} ・ <a href=https://github.com/maxmilton/trackx/issues rel=noopener>report bug</a></footer>
 <body>
 <html>`.replace(/\n\s+/g, '\n');
 }


### PR DESCRIPTION
Prevent external linked pages having access to `window.opener`.

Also change some `rel="noreferrer"` to `rel="noopener"` where it doesn't matter if the referrer header is sent.