### PR TITLE
fix: Support internationalised domains in email addresses

### DIFF
--- a/packages/trackx-api/src/routes/dash/login.ts
+++ b/packages/trackx-api/src/routes/dash/login.ts
@@ -5,11 +5,14 @@ import { Cookie } from 'tough-cookie';
 import { deniedDash } from '../../db';
 import type { ReqBodyData, ReqQueryData } from '../../types';
 import {
-  AppError, config, logger, sessions, Status, uid,
+  AppError,
+  config,
+  isNotValidEmail,
+  logger,
+  sessions,
+  Status,
+  uid,
 } from '../../utils';
-
-// https://github.com/angular/angular.js/blob/0633d8f2b0ac6cbad1c637768258b1f72994a614/src/ng/directive/input.js#L27
-const RE_EMAIL = /^(?=.{1,254}$)(?=.{1,64}@)[\w!#$%&'*+/=?^`{|}~-]+(\.[\w!#$%&'*+/=?^`{|}~-]+)*@[\dA-Za-z]([\dA-Za-z-]{0,61}[\dA-Za-z])?(\.[\dA-Za-z]([\dA-Za-z-]{0,61}[\dA-Za-z])?)*$/;
 
 export const options: Middleware = (_req, res) => {
   res.writeHead(Status.NO_CONTENT, {
@@ -52,7 +55,7 @@ export const post: Middleware = async (req, res, next) => {
       || password.length < 8
       // OWASP suggest max length of 64 for passwords -- https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls
       || password.length > 64
-      || !RE_EMAIL.test(email)
+      || isNotValidEmail(email)
       // eslint-disable-next-line no-cond-assign
       || !((userid = email.toLowerCase()) in config.USERS)
       || !(await verify(password, config.USERS[userid]))

--- a/packages/trackx-api/src/utils.ts
+++ b/packages/trackx-api/src/utils.ts
@@ -209,6 +209,14 @@ export function byteSize(data: string | object): number {
   );
 }
 
+// Same validation as packages/trackx-cli/src/actions/adduser.ts
+// https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+const RE_EMAIL = /^[\w!#$%&'*+./=?^`{|}~-]+@[\dA-Za-z](?:[\dA-Za-z-]{0,61}[\dA-Za-z])?(?:\.[\dA-Za-z](?:[\dA-Za-z-]{0,61}[\dA-Za-z])?)*$/;
+
+export function isNotValidEmail(email: string): boolean {
+  return !RE_EMAIL.test(email);
+}
+
 /**
  * Check a string is (not) comprised of only printable (not control) ASCII
  * characters from within the "ASCII" range (the first 128 characters in UTF-8).

--- a/packages/trackx-cli/package.json
+++ b/packages/trackx-cli/package.json
@@ -21,10 +21,12 @@
   "dependencies": {
     "better-sqlite3": "7.4.6",
     "kleur": "4.1.4",
+    "punycode": "2.1.1",
     "sade": "1.8.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.4.2",
+    "@types/punycode": "2.1.0",
     "@types/sade": "1.7.4",
     "git-ref": "0.3.1",
     "source-map-support": "0.5.21"

--- a/packages/trackx-cli/src/actions/adduser.ts
+++ b/packages/trackx-cli/src/actions/adduser.ts
@@ -9,13 +9,14 @@
 
 import crypto from 'crypto';
 import { bold, yellow } from 'kleur/colors';
+import { toASCII } from 'punycode/';
 import type { GlobalOptions } from '../types';
 import {
   containsControlChar,
   getConfig,
+  isValidEmail,
   logger,
   read,
-  validEmail,
 } from '../utils';
 
 function createHash(password: string): Promise<string> {
@@ -31,15 +32,18 @@ function createHash(password: string): Promise<string> {
 }
 
 async function getEmail(input?: string): Promise<string> {
-  const answer = input || (await read('Email: '));
+  let answer = input || (await read('Email: '));
 
   if (!answer) {
     logger.error('Email value required but not provided');
     return getEmail();
   }
 
-  if (!validEmail(answer)) {
-    logger.warn('Possibly an invalid email, please check it');
+  // Support international domains in email addresses e.g., user@例子.世界
+  answer = toASCII(answer);
+
+  if (!isValidEmail(answer)) {
+    logger.error('Possibly an invalid email, please double check it');
   }
 
   return answer;

--- a/packages/trackx-cli/src/utils.ts
+++ b/packages/trackx-cli/src/utils.ts
@@ -195,8 +195,12 @@ export function read(prompt: string, mask?: boolean): Promise<string> {
   });
 }
 
-export function validEmail(email: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+// Same validation as packages/trackx-api/src/routes/dash/login.ts
+// https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+const RE_EMAIL = /^[\w!#$%&'*+./=?^`{|}~-]+@[\dA-Za-z](?:[\dA-Za-z-]{0,61}[\dA-Za-z])?(?:\.[\dA-Za-z](?:[\dA-Za-z-]{0,61}[\dA-Za-z])?)*$/;
+
+export function isValidEmail(email: string): boolean {
+  return RE_EMAIL.test(email);
 }
 
 export function containsControlChar(str: string): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,18 +161,22 @@ importers:
   packages/trackx-cli:
     specifiers:
       '@types/better-sqlite3': 7.4.2
+      '@types/punycode': 2.1.0
       '@types/sade': 1.7.4
       better-sqlite3: 7.4.6
       git-ref: 0.3.1
       kleur: 4.1.4
+      punycode: 2.1.1
       sade: 1.8.1
       source-map-support: 0.5.21
     dependencies:
       better-sqlite3: 7.4.6
       kleur: 4.1.4
+      punycode: 2.1.1
       sade: 1.8.1
     devDependencies:
       '@types/better-sqlite3': 7.4.2
+      '@types/punycode': 2.1.0
       '@types/sade': 1.7.4
       git-ref: 0.3.1
       source-map-support: 0.5.21
@@ -1320,6 +1324,10 @@ packages:
 
   /@types/prettier/2.4.2:
     resolution: {integrity: sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==}
+    dev: true
+
+  /@types/punycode/2.1.0:
+    resolution: {integrity: sha512-PG5aLpW6PJOeV2fHRslP4IOMWn+G+Uq8CfnyJ+PDS8ndCbU+soO+fB3NKCKo0p/Jh2Y4aPaiQZsrOXFdzpcA6g==}
     dev: true
 
   /@types/resolve/1.17.1:


### PR DESCRIPTION
- E.g., user@例子.世界
- Also use the same email validation in `trackx-api` and `trackx-cli`