### PR TITLE
feat(trackx): Add experimental Node.js require hook

### DIFF
--- a/docs/guides/tracking-errors.md
+++ b/docs/guides/tracking-errors.md
@@ -8,8 +8,21 @@ Simple client-side event sampling rate
 
 ```js
 trackx.setup(
-  'https://api.trackx.app/v1/xxxxxxxxxxx/event',
+  'https://api.trackx.app/v1/xxxxxxxxxxx',
   // where 0.3 represents a 30% chance the event will be sent
   (payload) => (Math.random() < 0.3 ? payload : null),
 );
+```
+
+---
+
+### Node Require
+
+<!-- TODO: Update docs link in packages/trackx/require.js -->
+
+Using Node.js require hook
+
+```sh
+TRACKX_ENDPOINT=https://api.trackx.app/v1/xxxxxxxxxxx \
+  node -r trackx/require my-script.js
 ```

--- a/packages/trackx/require.js
+++ b/packages/trackx/require.js
@@ -1,0 +1,33 @@
+/**
+ * TrackX Node.js require hook
+ *
+ * @see https://docs.trackx.app/#/guides/tracking-errors.md#node-require
+ */
+
+// NOTE: This file is experimental and may be removed in the future.
+
+// FIXME: Experiment with use cases and different node versions, then decide if
+// we should keep this file.
+
+/* eslint-disable */ // @ts-nocheck
+
+const endpoint = process.env.TRACKX_ENDPOINT;
+const origin = process.env.TRACKX_ORIGIN;
+
+if (!endpoint) {
+  console.warn('TRACKX_ENDPOINT not set in env, not sending events');
+} else {
+  const trackx = require('trackx/node');
+  global.trackx = trackx;
+
+  function onError(payload, reason) {
+    if (!payload.meta.details && reason != null && typeof reason === 'object') {
+      const details = {};
+      for (const key in reason) details[key] = reason[key];
+      payload.meta.details = details;
+    }
+    return payload;
+  }
+
+  trackx.setup(endpoint, onError, origin);
+}


### PR DESCRIPTION
Add Node.js require hook to make it easy to set up error tracking for Node.js without needing to write any code.