### PR TITLE
Refactor out refetch and untrack in resource src

### DIFF
--- a/packages/trackx-api/src/routes/dash/project/[name]/newkey.ts
+++ b/packages/trackx-api/src/routes/dash/project/[name]/newkey.ts
@@ -16,7 +16,7 @@ const setNewProjectKeyStmt = db.prepare(
   'UPDATE project SET key = ? WHERE name = ?',
 );
 
-function setNewProjectKey(projectName: string): void {
+function setNewProjectKey(projectName: string) {
   const project = getProjectKeyByNameStmt.get(projectName) as
     | ProjectInternal
     | undefined;
@@ -33,6 +33,8 @@ function setNewProjectKey(projectName: string): void {
     `key-change-${project.key}`,
     `{"project_id":${project.id},"ts":${Date.now()},"to":"${newKey}"}`,
   );
+
+  return newKey;
 }
 
 export const post: Middleware = (req, res, next) => {
@@ -55,8 +57,8 @@ export const post: Middleware = (req, res, next) => {
       throw new AppError('Unexpected property', Status.BAD_REQUEST);
     }
 
-    setNewProjectKey(name);
-    res.end();
+    const key = setNewProjectKey(name);
+    res.end(key);
   } catch (error) {
     logger.error(error);
     void next(error || new Error(error));

--- a/packages/trackx-dash/src/pages/issues/[id].tsx
+++ b/packages/trackx-dash/src/pages/issues/[id].tsx
@@ -83,7 +83,7 @@ const IssuePage: RouteComponent = (props) => {
   const [urlParams, setUrlParams] = useURLParams();
   const initialUrlParams = urlParams();
   const [state, setState] = createStore({
-    error: null as any,
+    error: null as unknown,
     disablePrev: true,
     disableNext: true,
     dir: initialUrlParams.event ? null : 'last',

--- a/packages/trackx-dash/src/pages/issues/index.tsx
+++ b/packages/trackx-dash/src/pages/issues/index.tsx
@@ -37,7 +37,7 @@ const IssuesPage: RouteComponent = () => {
   const [urlParams, setUrlParams] = useURLParams();
   const initialUrlParams = urlParams();
   const [state, setState] = createStore({
-    error: null as any,
+    error: null as unknown,
     disableNext: true,
     disablePrev: true,
     resultsFrom: 0,

--- a/packages/trackx-dash/src/pages/projects/[name]/settings.tsx
+++ b/packages/trackx-dash/src/pages/projects/[name]/settings.tsx
@@ -26,8 +26,8 @@ import {
 
 const ProjectSettingsPage: RouteComponent = (props) => {
   const [state, setState] = createStore({
-    error: null as any,
-    validationError: null as any,
+    error: null as unknown,
+    validationError: null as unknown,
     disableSubmit: false,
     showConfirmNewKey: false,
     showConfirmRemove: false,

--- a/packages/trackx-dash/src/pages/projects/[name]/settings.tsx
+++ b/packages/trackx-dash/src/pages/projects/[name]/settings.tsx
@@ -43,7 +43,7 @@ const ProjectSettingsPage: RouteComponent = (props) => {
     setState({ error });
   });
 
-  const [project, projectActions] = createResource<Project, string>(
+  const [project, { mutate }] = createResource<Project, string>(
     () => `${config.DASH_API_ENDPOINT}/project/${props.params.name}`,
     fetchJSON,
   );
@@ -206,14 +206,16 @@ const ProjectSettingsPage: RouteComponent = (props) => {
         throw new AppError(await res.text(), res.status);
       }
 
+      const key = await res.text();
+      mutate((prev) => ({
+        ...prev!,
+        key,
+      }));
+
       setState({
         disableSubmit: false,
         showConfirmNewKey: false,
       });
-      // TODO: Generating a new key should just update/mutate the key in-place
-      // on the page rather than refetching the entire project and visually
-      // jarring the entire page
-      await projectActions.refetch();
     } catch (error: unknown) {
       // eslint-disable-next-line no-console
       console.error(error);

--- a/packages/trackx-dash/src/pages/projects/new.tsx
+++ b/packages/trackx-dash/src/pages/projects/new.tsx
@@ -36,8 +36,8 @@ import {
 
 const NewProjectPage: Component = () => {
   const [state, setState] = createStore({
-    error: null as any,
-    validationError: null as any,
+    error: null as unknown,
+    validationError: null as unknown,
     disableSubmit: false,
     origin: '',
     name: '',


### PR DESCRIPTION
Fix broken data fetching in dash.

- feat(trackx-api): Return new key as text from API `dash/project/[name]/newkey` endpoint
- feat(trackx-dash): Refactor out `untrack` from `createResource` source strings
- feat(trackx-dash): Refactor out use of `createResource` `refetch`
- feat(trackx-dash): Use better error type