### PR TITLE
bug: Move DB table stats feature behind config flag (temp workaround for #158)

### DIFF
--- a/packages/trackx-api/src/routes/dash/stats.ts
+++ b/packages/trackx-api/src/routes/dash/stats.ts
@@ -1,20 +1,19 @@
-/* eslint-disable max-len */
-
 import send from '@polka/send';
-// import { execFile } from 'child_process';
+import { execFile } from 'child_process';
 import fs from 'fs';
 import type { Middleware } from 'polka';
 import { db, deniedDash } from '../../db';
 import type {
   ReqQueryData,
   Stats,
-  // StatsDBTableInfo,
+  StatsDBTableInfo,
   TimeSeriesData,
 } from '../../types';
 import {
   AppError,
   config,
   humanFileSize,
+  humanizeTime,
   logger,
   sessions,
   Status,
@@ -118,167 +117,161 @@ function getStats(): Partial<Stats> {
   })();
 }
 
-// FIXME: Generating DB table stats is extremely slow on systems with slow disks
-//  ↳ https://github.com/maxmilton/trackx/issues/158
+function execCmd(cmd: string, args?: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, (error, stdout, stderr) => {
+      if (error || stderr) {
+        reject(error || stderr);
+      }
+      resolve(stdout);
+    });
+  });
+}
 
-// function execCmd(cmd: string, args?: string[]): Promise<string> {
-//   return new Promise((resolve, reject) => {
-//     execFile(cmd, args, (error, stdout, stderr) => {
-//       if (error || stderr) {
-//         reject(error || stderr);
-//       }
-//       resolve(stdout);
-//     });
-//   });
-// }
-
-// const tablePercent = (table: number, total: number) => `${((table / total) * 100).toFixed(2)}%`;
+const tablePercent = (table: number, total: number) => `${((table / total) * 100).toFixed(2)}%`;
 
 const humanizeSize = (stats: fs.Stats) => humanFileSize(stats.size);
 
-// const DB_QUERY = [
-//   'BEGIN TRANSACTION;',
-//   "SELECT SUM(pgsize) FROM dbstat('main',1);",
+const DB_QUERY = [
+  'BEGIN TRANSACTION;',
+  "SELECT SUM(pgsize) FROM dbstat('main',1);",
 
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='project';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue';",
-//   config.DB_COMPRESSION
-//     ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_event_zstd';"
-//     : "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_denied';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_events';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_pings';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='meta';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='project';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue';",
+  config.DB_COMPRESSION
+    ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_event_zstd';"
+    : "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_denied';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_events';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_pings';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='meta';",
 
-//   // "issue_fts" is a virtual table, so it doesn't have a size itself
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_config';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_data';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_docsize';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_idx';",
+  // "issue_fts" is a virtual table, so it doesn't have a size itself
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_config';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_data';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_docsize';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_idx';",
 
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session_graph';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session_issue';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_ts_last_idx';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_list_idx';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_state_idx';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event_graph_idx';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event_list_idx';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session_graph';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session_issue';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_ts_last_idx';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_list_idx';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_state_idx';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event_graph_idx';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event_list_idx';",
 
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_issue_1';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_project_1';",
-//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_project_2';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_issue_1';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_project_1';",
+  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_project_2';",
 
-//   config.DB_COMPRESSION
-//     ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_zstd_dicts';"
-//     : '',
-//   config.DB_COMPRESSION
-//     ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_data_dict_idx';"
-//     : '',
-//   'COMMIT;',
-// ].join('');
+  config.DB_COMPRESSION
+    ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_zstd_dicts';"
+    : '',
+  config.DB_COMPRESSION
+    ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_data_dict_idx';"
+    : '',
+  'COMMIT;',
+].join('');
 
-// async function getTableSizes() {
-//   try {
-//     // Because the better-sqlite3 npm module doesn't have the compile-time
-//     // SQLITE_ENABLE_DBSTAT_VTAB option enabled, to get table size data we need
-//     // to use the system sqlite3 CLI client which does support DBSTAT
-//     const t0 = performance.now();
-//     const output = await execCmd('/usr/bin/sqlite3', [
-//       '-safe',
-//       '-readonly',
-//       '-list',
-//       '-noheader',
-//       '-nullvalue',
-//       '0',
-//       '-cmd',
-//       '.eqp off',
-//       config.DB_PATH,
-//       DB_QUERY,
-//     ]);
-//     const t1 = performance.now();
-//     console.log(`DB exec took ${(t1 - t0).toFixed(2)} ms`);
-//     const data = output.toString().split('\n');
-//     const total = +data[0];
-//     const project = +data[1];
-//     const session = +data[2];
-//     const issue = +data[3];
-//     const event = +data[4];
-//     const daily_denied = +data[5];
-//     const daily_events = +data[6];
-//     const daily_pings = +data[7];
-//     const meta = +data[8];
-//     const issue_fts = +data[9] + +data[10] + +data[11] + +data[12];
-//     const session_graph = +data[13];
-//     const session_issue = +data[14];
-//     const issue_ts_last_idx = +data[15];
-//     const issue_list_idx = +data[16];
-//     const issue_state_idx = +data[17];
-//     const event_graph_idx = +data[18];
-//     const event_list_idx = +data[19];
-//     const sqlite_autoindex_issue_1 = +data[20];
-//     const sqlite_autoindex_project_1 = +data[21];
-//     const sqlite_autoindex_project_2 = +data[22];
+async function getTableSizes() {
+  try {
+    // Because the better-sqlite3 npm module doesn't have the compile-time
+    // SQLITE_ENABLE_DBSTAT_VTAB option enabled, to get table size data we need
+    // to use the system sqlite3 CLI client which does support DBSTAT
+    const output = await execCmd('/usr/bin/sqlite3', [
+      '-safe',
+      '-readonly',
+      '-list',
+      '-noheader',
+      '-nullvalue',
+      '0',
+      '-cmd',
+      '.eqp off',
+      config.DB_PATH,
+      DB_QUERY,
+    ]);
+    const data = output.toString().split('\n');
+    const total = +data[0];
+    const project = +data[1];
+    const session = +data[2];
+    const issue = +data[3];
+    const event = +data[4];
+    const daily_denied = +data[5];
+    const daily_events = +data[6];
+    const daily_pings = +data[7];
+    const meta = +data[8];
+    const issue_fts = +data[9] + +data[10] + +data[11] + +data[12];
+    const session_graph = +data[13];
+    const session_issue = +data[14];
+    const issue_ts_last_idx = +data[15];
+    const issue_list_idx = +data[16];
+    const issue_state_idx = +data[17];
+    const event_graph_idx = +data[18];
+    const event_list_idx = +data[19];
+    const sqlite_autoindex_issue_1 = +data[20];
+    const sqlite_autoindex_project_1 = +data[21];
+    const sqlite_autoindex_project_2 = +data[22];
 
-//     const tablesInfo = [
-//       /* prettier-ignore */
-//       [project, ['project', humanFileSize(project), tablePercent(project, total)]],
-//       /* prettier-ignore */
-//       [session, ['session', humanFileSize(session), tablePercent(session, total)]],
-//       /* prettier-ignore */
-//       [issue, ['issue', humanFileSize(issue), tablePercent(issue, total)]],
-//       /* prettier-ignore */
-//       [event, ['event', humanFileSize(event), tablePercent(event, total)]],
-//       /* prettier-ignore */
-//       [daily_denied, ['daily_denied', humanFileSize(daily_denied), tablePercent(daily_denied, total)]],
-//       /* prettier-ignore */
-//       [daily_events, ['daily_events', humanFileSize(daily_events), tablePercent(daily_events, total)]],
-//       /* prettier-ignore */
-//       [daily_pings, ['daily_pings', humanFileSize(daily_pings), tablePercent(daily_pings, total)]],
-//       /* prettier-ignore */
-//       [meta, ['meta', humanFileSize(meta), tablePercent(meta, total)]],
-//       /* prettier-ignore */
-//       [issue_fts, ['issue_fts*', humanFileSize(issue_fts), tablePercent(issue_fts, total)]],
-//       /* prettier-ignore */
-//       [session_graph, ['session_graph', humanFileSize(session_graph), tablePercent(session_graph, total)]],
-//       /* prettier-ignore */
-//       [session_issue, ['session_issue', humanFileSize(session_issue), tablePercent(session_issue, total)]],
-//       /* prettier-ignore */
-//       [issue_ts_last_idx, ['issue_ts_last_idx', humanFileSize(issue_ts_last_idx), tablePercent(issue_ts_last_idx, total)]],
-//       /* prettier-ignore */
-//       [issue_list_idx, ['issue_list_idx', humanFileSize(issue_list_idx), tablePercent(issue_list_idx, total)]],
-//       /* prettier-ignore */
-//       [issue_state_idx, ['issue_state_idx', humanFileSize(issue_state_idx), tablePercent(issue_state_idx, total)]],
-//       /* prettier-ignore */
-//       [event_graph_idx, ['event_graph_idx', humanFileSize(event_graph_idx), tablePercent(event_graph_idx, total)]],
-//       /* prettier-ignore */
-//       [event_list_idx, ['event_list_idx', humanFileSize(event_list_idx), tablePercent(event_list_idx, total)]],
-//       /* prettier-ignore */
-//       [sqlite_autoindex_issue_1, ['sqlite_autoindex_issue_1', humanFileSize(sqlite_autoindex_issue_1), tablePercent(sqlite_autoindex_issue_1, total)]],
-//       /* prettier-ignore */
-//       [sqlite_autoindex_project_1, ['sqlite_autoindex_project_1', humanFileSize(sqlite_autoindex_project_1), tablePercent(sqlite_autoindex_project_1, total)]],
-//       /* prettier-ignore */
-//       [sqlite_autoindex_project_2, ['sqlite_autoindex_project_2', humanFileSize(sqlite_autoindex_project_2), tablePercent(sqlite_autoindex_project_2, total)]],
-//     ] as [number, StatsDBTableInfo][];
+    const tablesInfo = [
+      /* prettier-ignore */
+      [project, ['project', humanFileSize(project), tablePercent(project, total)]],
+      /* prettier-ignore */
+      [session, ['session', humanFileSize(session), tablePercent(session, total)]],
+      /* prettier-ignore */
+      [issue, ['issue', humanFileSize(issue), tablePercent(issue, total)]],
+      /* prettier-ignore */
+      [event, ['event', humanFileSize(event), tablePercent(event, total)]],
+      /* prettier-ignore */
+      [daily_denied, ['daily_denied', humanFileSize(daily_denied), tablePercent(daily_denied, total)]],
+      /* prettier-ignore */
+      [daily_events, ['daily_events', humanFileSize(daily_events), tablePercent(daily_events, total)]],
+      /* prettier-ignore */
+      [daily_pings, ['daily_pings', humanFileSize(daily_pings), tablePercent(daily_pings, total)]],
+      /* prettier-ignore */
+      [meta, ['meta', humanFileSize(meta), tablePercent(meta, total)]],
+      /* prettier-ignore */
+      [issue_fts, ['issue_fts*', humanFileSize(issue_fts), tablePercent(issue_fts, total)]],
+      /* prettier-ignore */
+      [session_graph, ['session_graph', humanFileSize(session_graph), tablePercent(session_graph, total)]],
+      /* prettier-ignore */
+      [session_issue, ['session_issue', humanFileSize(session_issue), tablePercent(session_issue, total)]],
+      /* prettier-ignore */
+      [issue_ts_last_idx, ['issue_ts_last_idx', humanFileSize(issue_ts_last_idx), tablePercent(issue_ts_last_idx, total)]],
+      /* prettier-ignore */
+      [issue_list_idx, ['issue_list_idx', humanFileSize(issue_list_idx), tablePercent(issue_list_idx, total)]],
+      /* prettier-ignore */
+      [issue_state_idx, ['issue_state_idx', humanFileSize(issue_state_idx), tablePercent(issue_state_idx, total)]],
+      /* prettier-ignore */
+      [event_graph_idx, ['event_graph_idx', humanFileSize(event_graph_idx), tablePercent(event_graph_idx, total)]],
+      /* prettier-ignore */
+      [event_list_idx, ['event_list_idx', humanFileSize(event_list_idx), tablePercent(event_list_idx, total)]],
+      /* prettier-ignore */
+      [sqlite_autoindex_issue_1, ['sqlite_autoindex_issue_1', humanFileSize(sqlite_autoindex_issue_1), tablePercent(sqlite_autoindex_issue_1, total)]],
+      /* prettier-ignore */
+      [sqlite_autoindex_project_1, ['sqlite_autoindex_project_1', humanFileSize(sqlite_autoindex_project_1), tablePercent(sqlite_autoindex_project_1, total)]],
+      /* prettier-ignore */
+      [sqlite_autoindex_project_2, ['sqlite_autoindex_project_2', humanFileSize(sqlite_autoindex_project_2), tablePercent(sqlite_autoindex_project_2, total)]],
+    ] as [number, StatsDBTableInfo][];
 
-//     if (config.DB_COMPRESSION) {
-//       const zstd_dicts = +data[23];
-//       const data_dict_idx = +data[24];
+    if (config.DB_COMPRESSION) {
+      const zstd_dicts = +data[23];
+      const data_dict_idx = +data[24];
 
-//       tablesInfo.push(
-//         /* prettier-ignore */
-//         [zstd_dicts, ['_zstd_dicts', humanFileSize(zstd_dicts), tablePercent(zstd_dicts, total)]],
-//         /* prettier-ignore */
-//         [data_dict_idx, ['_data_dict_idx', humanFileSize(data_dict_idx), tablePercent(data_dict_idx, total)]],
-//       );
-//     }
+      tablesInfo.push(
+        /* prettier-ignore */
+        [zstd_dicts, ['_zstd_dicts', humanFileSize(zstd_dicts), tablePercent(zstd_dicts, total)]],
+        /* prettier-ignore */
+        [data_dict_idx, ['_data_dict_idx', humanFileSize(data_dict_idx), tablePercent(data_dict_idx, total)]],
+      );
+    }
 
-//     return tablesInfo.sort((a, b) => b[0] - a[0]).map((row) => row[1]);
-//   } catch (error) {
-//     logger.error(error);
-//     return [];
-//   }
-// }
+    return tablesInfo.sort((a, b) => b[0] - a[0]).map((row) => row[1]);
+  } catch (error) {
+    logger.error(error);
+    return [];
+  }
+}
 
 export const get: Middleware = async (req, res, next) => {
   try {
@@ -288,11 +281,6 @@ export const get: Middleware = async (req, res, next) => {
       throw new AppError('Unexpected param', Status.BAD_REQUEST);
     }
 
-    // const [tableSizes, dbFileSize, dbWalFileSize] = await Promise.all([
-    //   getTableSizes(),
-    //   fs.promises.stat(config.DB_PATH).then(humanizeSize),
-    //   fs.promises.stat(`${config.DB_PATH}-wal`).then(humanizeSize),
-    // ]);
     const [dbFileSize, dbWalFileSize] = await Promise.all([
       fs.promises.stat(config.DB_PATH).then(humanizeSize),
       fs.promises.stat(`${config.DB_PATH}-wal`).then(humanizeSize),
@@ -304,6 +292,15 @@ export const get: Middleware = async (req, res, next) => {
     data.db_size = dbFileSize;
     data.dbwal_size = dbWalFileSize;
     // data.db_tables = tableSizes;
+
+    // FIXME: Generating DB table stats is extremely slow on systems with slow disks
+    //  ↳ https://github.com/maxmilton/trackx/issues/158
+    if (config.ENABLE_DB_TABLE_STATS) {
+      const t0 = performance.now();
+      data.db_tables = await getTableSizes();
+      const t1 = performance.now();
+      logger.info(`Generated DB table stats in ${humanizeTime(t1 - t0)}`);
+    }
 
     send(res, Status.OK, data);
   } catch (error) {

--- a/packages/trackx-api/src/routes/dash/stats.ts
+++ b/packages/trackx-api/src/routes/dash/stats.ts
@@ -1,12 +1,14 @@
+/* eslint-disable max-len */
+
 import send from '@polka/send';
-import { execFile } from 'child_process';
+// import { execFile } from 'child_process';
 import fs from 'fs';
 import type { Middleware } from 'polka';
 import { db, deniedDash } from '../../db';
 import type {
   ReqQueryData,
   Stats,
-  StatsDBTableInfo,
+  // StatsDBTableInfo,
   TimeSeriesData,
 } from '../../types';
 import {
@@ -116,161 +118,167 @@ function getStats(): Partial<Stats> {
   })();
 }
 
-function execCmd(cmd: string, args?: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile(cmd, args, (error, stdout, stderr) => {
-      if (error || stderr) {
-        reject(error || stderr);
-      }
-      resolve(stdout);
-    });
-  });
-}
+// FIXME: Generating DB table stats is extremely slow on systems with slow disks
+//  ↳ https://github.com/maxmilton/trackx/issues/158
 
-const tablePercent = (table: number, total: number) => `${((table / total) * 100).toFixed(2)}%`;
+// function execCmd(cmd: string, args?: string[]): Promise<string> {
+//   return new Promise((resolve, reject) => {
+//     execFile(cmd, args, (error, stdout, stderr) => {
+//       if (error || stderr) {
+//         reject(error || stderr);
+//       }
+//       resolve(stdout);
+//     });
+//   });
+// }
+
+// const tablePercent = (table: number, total: number) => `${((table / total) * 100).toFixed(2)}%`;
 
 const humanizeSize = (stats: fs.Stats) => humanFileSize(stats.size);
 
-const DB_QUERY = [
-  'BEGIN TRANSACTION;',
-  "SELECT SUM(pgsize) FROM dbstat('main',1);",
+// const DB_QUERY = [
+//   'BEGIN TRANSACTION;',
+//   "SELECT SUM(pgsize) FROM dbstat('main',1);",
 
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='project';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue';",
-  config.DB_COMPRESSION
-    ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_event_zstd';"
-    : "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_denied';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_events';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_pings';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='meta';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='project';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue';",
+//   config.DB_COMPRESSION
+//     ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_event_zstd';"
+//     : "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_denied';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_events';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='daily_pings';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='meta';",
 
-  // "issue_fts" is a virtual table, so it doesn't have a size itself
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_config';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_data';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_docsize';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_idx';",
+//   // "issue_fts" is a virtual table, so it doesn't have a size itself
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_config';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_data';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_docsize';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_fts_idx';",
 
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session_graph';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session_issue';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_ts_last_idx';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_list_idx';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_state_idx';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event_graph_idx';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event_list_idx';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session_graph';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='session_issue';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_ts_last_idx';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_list_idx';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='issue_state_idx';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event_graph_idx';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='event_list_idx';",
 
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_issue_1';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_project_1';",
-  "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_project_2';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_issue_1';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_project_1';",
+//   "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='sqlite_autoindex_project_2';",
 
-  config.DB_COMPRESSION
-    ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_zstd_dicts';"
-    : '',
-  config.DB_COMPRESSION
-    ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_data_dict_idx';"
-    : '',
-  'COMMIT;',
-].join('');
+//   config.DB_COMPRESSION
+//     ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_zstd_dicts';"
+//     : '',
+//   config.DB_COMPRESSION
+//     ? "SELECT SUM(pgsize) FROM dbstat('main',1) WHERE name='_data_dict_idx';"
+//     : '',
+//   'COMMIT;',
+// ].join('');
 
-async function getTableSizes() {
-  try {
-    // Because the better-sqlite3 npm module doesn't have the compile-time
-    // SQLITE_ENABLE_DBSTAT_VTAB option enabled, to get table size data we need
-    // to use the system sqlite3 CLI client which does support DBSTAT
-    const output = await execCmd('/usr/bin/sqlite3', [
-      '-safe',
-      '-readonly',
-      '-list',
-      '-noheader',
-      '-nullvalue',
-      '0',
-      '-cmd',
-      '.eqp off',
-      config.DB_PATH,
-      DB_QUERY,
-    ]);
-    const data = output.toString().split('\n');
-    const total = +data[0];
-    const project = +data[1];
-    const session = +data[2];
-    const issue = +data[3];
-    const event = +data[4];
-    const daily_denied = +data[5];
-    const daily_events = +data[6];
-    const daily_pings = +data[7];
-    const meta = +data[8];
-    const issue_fts = +data[9] + +data[10] + +data[11] + +data[12];
-    const session_graph = +data[13];
-    const session_issue = +data[14];
-    const issue_ts_last_idx = +data[15];
-    const issue_list_idx = +data[16];
-    const issue_state_idx = +data[17];
-    const event_graph_idx = +data[18];
-    const event_list_idx = +data[19];
-    const sqlite_autoindex_issue_1 = +data[20];
-    const sqlite_autoindex_project_1 = +data[21];
-    const sqlite_autoindex_project_2 = +data[22];
+// async function getTableSizes() {
+//   try {
+//     // Because the better-sqlite3 npm module doesn't have the compile-time
+//     // SQLITE_ENABLE_DBSTAT_VTAB option enabled, to get table size data we need
+//     // to use the system sqlite3 CLI client which does support DBSTAT
+//     const t0 = performance.now();
+//     const output = await execCmd('/usr/bin/sqlite3', [
+//       '-safe',
+//       '-readonly',
+//       '-list',
+//       '-noheader',
+//       '-nullvalue',
+//       '0',
+//       '-cmd',
+//       '.eqp off',
+//       config.DB_PATH,
+//       DB_QUERY,
+//     ]);
+//     const t1 = performance.now();
+//     console.log(`DB exec took ${(t1 - t0).toFixed(2)} ms`);
+//     const data = output.toString().split('\n');
+//     const total = +data[0];
+//     const project = +data[1];
+//     const session = +data[2];
+//     const issue = +data[3];
+//     const event = +data[4];
+//     const daily_denied = +data[5];
+//     const daily_events = +data[6];
+//     const daily_pings = +data[7];
+//     const meta = +data[8];
+//     const issue_fts = +data[9] + +data[10] + +data[11] + +data[12];
+//     const session_graph = +data[13];
+//     const session_issue = +data[14];
+//     const issue_ts_last_idx = +data[15];
+//     const issue_list_idx = +data[16];
+//     const issue_state_idx = +data[17];
+//     const event_graph_idx = +data[18];
+//     const event_list_idx = +data[19];
+//     const sqlite_autoindex_issue_1 = +data[20];
+//     const sqlite_autoindex_project_1 = +data[21];
+//     const sqlite_autoindex_project_2 = +data[22];
 
-    const tablesInfo = [
-      /* prettier-ignore */
-      [project, ['project', humanFileSize(project), tablePercent(project, total)]],
-      /* prettier-ignore */
-      [session, ['session', humanFileSize(session), tablePercent(session, total)]],
-      /* prettier-ignore */
-      [issue, ['issue', humanFileSize(issue), tablePercent(issue, total)]],
-      /* prettier-ignore */
-      [event, ['event', humanFileSize(event), tablePercent(event, total)]],
-      /* prettier-ignore */
-      [daily_denied, ['daily_denied', humanFileSize(daily_denied), tablePercent(daily_denied, total)]],
-      /* prettier-ignore */
-      [daily_events, ['daily_events', humanFileSize(daily_events), tablePercent(daily_events, total)]],
-      /* prettier-ignore */
-      [daily_pings, ['daily_pings', humanFileSize(daily_pings), tablePercent(daily_pings, total)]],
-      /* prettier-ignore */
-      [meta, ['meta', humanFileSize(meta), tablePercent(meta, total)]],
-      /* prettier-ignore */
-      [issue_fts, ['issue_fts*', humanFileSize(issue_fts), tablePercent(issue_fts, total)]],
-      /* prettier-ignore */
-      [session_graph, ['session_graph', humanFileSize(session_graph), tablePercent(session_graph, total)]],
-      /* prettier-ignore */
-      [session_issue, ['session_issue', humanFileSize(session_issue), tablePercent(session_issue, total)]],
-      /* prettier-ignore */
-      [issue_ts_last_idx, ['issue_ts_last_idx', humanFileSize(issue_ts_last_idx), tablePercent(issue_ts_last_idx, total)]],
-      /* prettier-ignore */
-      [issue_list_idx, ['issue_list_idx', humanFileSize(issue_list_idx), tablePercent(issue_list_idx, total)]],
-      /* prettier-ignore */
-      [issue_state_idx, ['issue_state_idx', humanFileSize(issue_state_idx), tablePercent(issue_state_idx, total)]],
-      /* prettier-ignore */
-      [event_graph_idx, ['event_graph_idx', humanFileSize(event_graph_idx), tablePercent(event_graph_idx, total)]],
-      /* prettier-ignore */
-      [event_list_idx, ['event_list_idx', humanFileSize(event_list_idx), tablePercent(event_list_idx, total)]],
-      /* prettier-ignore */
-      [sqlite_autoindex_issue_1, ['sqlite_autoindex_issue_1', humanFileSize(sqlite_autoindex_issue_1), tablePercent(sqlite_autoindex_issue_1, total)]],
-      /* prettier-ignore */
-      [sqlite_autoindex_project_1, ['sqlite_autoindex_project_1', humanFileSize(sqlite_autoindex_project_1), tablePercent(sqlite_autoindex_project_1, total)]],
-      /* prettier-ignore */
-      [sqlite_autoindex_project_2, ['sqlite_autoindex_project_2', humanFileSize(sqlite_autoindex_project_2), tablePercent(sqlite_autoindex_project_2, total)]],
-    ] as [number, StatsDBTableInfo][];
+//     const tablesInfo = [
+//       /* prettier-ignore */
+//       [project, ['project', humanFileSize(project), tablePercent(project, total)]],
+//       /* prettier-ignore */
+//       [session, ['session', humanFileSize(session), tablePercent(session, total)]],
+//       /* prettier-ignore */
+//       [issue, ['issue', humanFileSize(issue), tablePercent(issue, total)]],
+//       /* prettier-ignore */
+//       [event, ['event', humanFileSize(event), tablePercent(event, total)]],
+//       /* prettier-ignore */
+//       [daily_denied, ['daily_denied', humanFileSize(daily_denied), tablePercent(daily_denied, total)]],
+//       /* prettier-ignore */
+//       [daily_events, ['daily_events', humanFileSize(daily_events), tablePercent(daily_events, total)]],
+//       /* prettier-ignore */
+//       [daily_pings, ['daily_pings', humanFileSize(daily_pings), tablePercent(daily_pings, total)]],
+//       /* prettier-ignore */
+//       [meta, ['meta', humanFileSize(meta), tablePercent(meta, total)]],
+//       /* prettier-ignore */
+//       [issue_fts, ['issue_fts*', humanFileSize(issue_fts), tablePercent(issue_fts, total)]],
+//       /* prettier-ignore */
+//       [session_graph, ['session_graph', humanFileSize(session_graph), tablePercent(session_graph, total)]],
+//       /* prettier-ignore */
+//       [session_issue, ['session_issue', humanFileSize(session_issue), tablePercent(session_issue, total)]],
+//       /* prettier-ignore */
+//       [issue_ts_last_idx, ['issue_ts_last_idx', humanFileSize(issue_ts_last_idx), tablePercent(issue_ts_last_idx, total)]],
+//       /* prettier-ignore */
+//       [issue_list_idx, ['issue_list_idx', humanFileSize(issue_list_idx), tablePercent(issue_list_idx, total)]],
+//       /* prettier-ignore */
+//       [issue_state_idx, ['issue_state_idx', humanFileSize(issue_state_idx), tablePercent(issue_state_idx, total)]],
+//       /* prettier-ignore */
+//       [event_graph_idx, ['event_graph_idx', humanFileSize(event_graph_idx), tablePercent(event_graph_idx, total)]],
+//       /* prettier-ignore */
+//       [event_list_idx, ['event_list_idx', humanFileSize(event_list_idx), tablePercent(event_list_idx, total)]],
+//       /* prettier-ignore */
+//       [sqlite_autoindex_issue_1, ['sqlite_autoindex_issue_1', humanFileSize(sqlite_autoindex_issue_1), tablePercent(sqlite_autoindex_issue_1, total)]],
+//       /* prettier-ignore */
+//       [sqlite_autoindex_project_1, ['sqlite_autoindex_project_1', humanFileSize(sqlite_autoindex_project_1), tablePercent(sqlite_autoindex_project_1, total)]],
+//       /* prettier-ignore */
+//       [sqlite_autoindex_project_2, ['sqlite_autoindex_project_2', humanFileSize(sqlite_autoindex_project_2), tablePercent(sqlite_autoindex_project_2, total)]],
+//     ] as [number, StatsDBTableInfo][];
 
-    if (config.DB_COMPRESSION) {
-      const zstd_dicts = +data[23];
-      const data_dict_idx = +data[24];
+//     if (config.DB_COMPRESSION) {
+//       const zstd_dicts = +data[23];
+//       const data_dict_idx = +data[24];
 
-      tablesInfo.push(
-        /* prettier-ignore */
-        [zstd_dicts, ['_zstd_dicts', humanFileSize(zstd_dicts), tablePercent(zstd_dicts, total)]],
-        /* prettier-ignore */
-        [data_dict_idx, ['_data_dict_idx', humanFileSize(data_dict_idx), tablePercent(data_dict_idx, total)]],
-      );
-    }
+//       tablesInfo.push(
+//         /* prettier-ignore */
+//         [zstd_dicts, ['_zstd_dicts', humanFileSize(zstd_dicts), tablePercent(zstd_dicts, total)]],
+//         /* prettier-ignore */
+//         [data_dict_idx, ['_data_dict_idx', humanFileSize(data_dict_idx), tablePercent(data_dict_idx, total)]],
+//       );
+//     }
 
-    return tablesInfo.sort((a, b) => b[0] - a[0]).map((row) => row[1]);
-  } catch (error) {
-    logger.error(error);
-    return [];
-  }
-}
+//     return tablesInfo.sort((a, b) => b[0] - a[0]).map((row) => row[1]);
+//   } catch (error) {
+//     logger.error(error);
+//     return [];
+//   }
+// }
 
 export const get: Middleware = async (req, res, next) => {
   try {
@@ -280,8 +288,12 @@ export const get: Middleware = async (req, res, next) => {
       throw new AppError('Unexpected param', Status.BAD_REQUEST);
     }
 
-    const [tableSizes, dbFileSize, dbWalFileSize] = await Promise.all([
-      getTableSizes(),
+    // const [tableSizes, dbFileSize, dbWalFileSize] = await Promise.all([
+    //   getTableSizes(),
+    //   fs.promises.stat(config.DB_PATH).then(humanizeSize),
+    //   fs.promises.stat(`${config.DB_PATH}-wal`).then(humanizeSize),
+    // ]);
+    const [dbFileSize, dbWalFileSize] = await Promise.all([
       fs.promises.stat(config.DB_PATH).then(humanizeSize),
       fs.promises.stat(`${config.DB_PATH}-wal`).then(humanizeSize),
     ]);
@@ -291,7 +303,7 @@ export const get: Middleware = async (req, res, next) => {
     data.api_uptime = Math.floor(process.uptime());
     data.db_size = dbFileSize;
     data.dbwal_size = dbWalFileSize;
-    data.db_tables = tableSizes;
+    // data.db_tables = tableSizes;
 
     send(res, Status.OK, data);
   } catch (error) {

--- a/packages/trackx-api/src/types.ts
+++ b/packages/trackx-api/src/types.ts
@@ -147,6 +147,15 @@ export interface TrackXAPIConfig {
    * token expires, the user must login again.
    */
   readonly SESSION_TTL: number;
+
+  /**
+   * Show database table size statistics on the dash `/stats` page.
+   *
+   * @remarks Currently has known performance issues. Enabling this feature may
+   * be useful for debugging and observability but should be disabled in
+   * production to prevent a potential denial-of-service attack vector.
+   */
+  readonly ENABLE_DB_TABLE_STATS?: boolean;
 }
 
 export type ReqBodyData = Record<string, unknown>;
@@ -325,7 +334,8 @@ export interface Stats {
   dash_session_c: number;
   db_size: string;
   dbwal_size: string;
-  db_tables: StatsDBTableInfo[];
+  // Optional because it's behind the config flag "ENABLE_DB_TABLE_STATS"
+  db_tables?: StatsDBTableInfo[];
 }
 
 export interface Logs {

--- a/packages/trackx-api/src/utils.ts
+++ b/packages/trackx-api/src/utils.ts
@@ -190,6 +190,26 @@ export function generateSalt(rounds: number): string {
     .slice(0, rounds);
 }
 
+export function humanizeTime(ms: number): string {
+  const periods = {
+    d: Math.floor(ms / (1000 * 60 * 60 * 24)),
+    h: Math.floor((ms % (1000 * 60 * 60)) / 24),
+    m: Math.floor((ms % (1000 * 60)) / 60),
+    s: Math.floor((ms % 1000) / 60),
+    ms: Math.floor(ms % 1000),
+  };
+  const keep = [];
+  let key: keyof typeof periods;
+
+  for (key in periods) {
+    if (periods[key] > 0) {
+      keep.push(`${periods[key]}${key}`);
+    }
+  }
+
+  return keep.join(' ');
+}
+
 export function humanFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   let b = bytes;

--- a/packages/trackx-api/trackx.config.js
+++ b/packages/trackx-api/trackx.config.js
@@ -35,4 +35,6 @@ module.exports = {
   NET_TIMEOUT: 30_000, // 30 seconds
   SCHEDULED_JOB_INTERVAL: 21_600_000, // 6 hours; 6h * 60m * 60s * 1000ms
   SESSION_TTL: 2_400_000, // 40 minutes; 40m * 60s * 1000ms
+
+  ENABLE_DB_TABLE_STATS: true,
 };

--- a/packages/trackx-api/trackx.config.js.template
+++ b/packages/trackx-api/trackx.config.js.template
@@ -22,4 +22,6 @@ module.exports = {
   NET_TIMEOUT: 30000, // 30 seconds
   SCHEDULED_JOB_INTERVAL: 21600000, // 6 hours
   SESSION_TTL: 2400000, // 40 minutes
+
+  ENABLE_DB_TABLE_STATS: false,
 };

--- a/packages/trackx-cli/src/utils.ts
+++ b/packages/trackx-cli/src/utils.ts
@@ -53,6 +53,8 @@ const CONFIG_SCHEMA = [
   ['NET_TIMEOUT', ['Number']],
   ['SCHEDULED_JOB_INTERVAL', ['Number']],
   ['SESSION_TTL', ['Number']],
+
+  ['ENABLE_DB_TABLE_STATS', ['Boolean', 'Undefined']],
 ] as const;
 const configExpectedKeys: string[] = CONFIG_SCHEMA.map((item) => item[0]);
 
@@ -84,8 +86,9 @@ function validateConfig(
   }
 
   for (const [key, types] of CONFIG_SCHEMA) {
-    if (!(key in rawConfig)) {
-      errors.push(new ReferenceError(`Config missing "${key}" key`));
+    // @ts-expect-error - FIXME: "types" type
+    if (!(key in rawConfig) && !types.includes('Undefined')) {
+      errors.push(new ReferenceError(`Config missing required "${key}" key`));
     }
 
     const valueType = toStr

--- a/packages/trackx-dash/src/pages/stats.tsx
+++ b/packages/trackx-dash/src/pages/stats.tsx
@@ -1,6 +1,10 @@
 import reltime from '@trackx/reltime';
 import { createEffect, createResource, type Component } from 'solid-js';
-import { For, Match, Switch } from 'solid-js/web';
+import {
+  // For,
+  Match,
+  Switch,
+} from 'solid-js/web';
 import UPlot from 'uplot';
 import type { Stats, TimeSeriesData } from '../../../trackx-api/src/types';
 import { renderErrorAlert } from '../components/ErrorAlert';

--- a/packages/trackx-dash/src/pages/stats.tsx
+++ b/packages/trackx-dash/src/pages/stats.tsx
@@ -1,10 +1,6 @@
 import reltime from '@trackx/reltime';
 import { createEffect, createResource, type Component } from 'solid-js';
-import {
-  // For,
-  Match,
-  Switch,
-} from 'solid-js/web';
+import { For, Match, Switch } from 'solid-js/web';
 import UPlot from 'uplot';
 import type { Stats, TimeSeriesData } from '../../../trackx-api/src/types';
 import { renderErrorAlert } from '../components/ErrorAlert';
@@ -143,8 +139,7 @@ const StatsPage: Component = () => {
               <div>
                 <h2>Database</h2>
 
-                {/* TODO: Remove class=wsnb once no longer necessary */}
-                <p class="wsnb">
+                <p class="wsn">
                   {data.db_size}
                   <span class="muted"> + </span>
                   {data.dbwal_size}
@@ -153,23 +148,25 @@ const StatsPage: Component = () => {
 
                 {/* FIXME: Generating DB table stats is extremely slow on systems
                 with slow disks -- https://github.com/maxmilton/trackx/issues/158 */}
-                {/*
-                <h3>Tables</h3>
+                {data.db_tables && (
+                  <>
+                    <h3>Tables</h3>
 
-                <div class="table-wrapper">
-                  <table class="table wi tr tnum">
-                    <For each={data.db_tables} fallback="No data">
-                      {([name, size, percent]) => (
-                        <tr>
-                          <td class="tl break" textContent={name} />
-                          <td class="wsn" textContent={size} />
-                          <td textContent={percent} />
-                        </tr>
-                      )}
-                    </For>
-                  </table>
-                </div>
-                */}
+                    <div class="table-wrapper">
+                      <table class="table wi tr tnum">
+                        <For each={data.db_tables} fallback="No data">
+                          {([name, size, percent]) => (
+                            <tr>
+                              <td class="tl break" textContent={name} />
+                              <td class="wsn" textContent={size} />
+                              <td textContent={percent} />
+                            </tr>
+                          )}
+                        </For>
+                      </table>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
           )}

--- a/packages/trackx-dash/src/pages/stats.tsx
+++ b/packages/trackx-dash/src/pages/stats.tsx
@@ -139,13 +139,17 @@ const StatsPage: Component = () => {
               <div>
                 <h2>Database</h2>
 
-                <p>
+                {/* TODO: Remove class=wsnb once no longer necessary */}
+                <p class="wsnb">
                   {data.db_size}
                   <span class="muted"> + </span>
                   {data.dbwal_size}
                   <span class="muted"> (wal)</span>
                 </p>
 
+                {/* FIXME: Generating DB table stats is extremely slow on systems
+                with slow disks -- https://github.com/maxmilton/trackx/issues/158 */}
+                {/*
                 <h3>Tables</h3>
 
                 <div class="table-wrapper">
@@ -161,6 +165,7 @@ const StatsPage: Component = () => {
                     </For>
                   </table>
                 </div>
+                */}
               </div>
             </div>
           )}


### PR DESCRIPTION
- feat: Add new `ENABLE_DB_TABLE_STATS` config key + set to `false` to disable by default (and `true` for development)
- feat(trackx-api): Log time taken to generate DB table data
- bug(trackx-cli): Don't fail config check if optional config key is missing
- feat(trackx-dash): Only show DB table stats if the data is availiable