### PR TITLE
bug(trackx-api): Increase arbitrary event data limits to user config value

### DIFF
--- a/packages/trackx-api/src/index.ts
+++ b/packages/trackx-api/src/index.ts
@@ -93,6 +93,14 @@ for (const route of routes) {
           ) {
             const limit = 300 * 1024 * 1024; // 300MiB
             app[method](route.path, text({ limit }), handler);
+          } else if (route.path === '/v1/:key/event') {
+            app[method](
+              route.path,
+              // TODO: Should the incoming event max body size be a separate
+              // config option rather than MAX_EVENT_BYTES?
+              json({ limit: config.MAX_EVENT_BYTES }),
+              handler,
+            );
           } else if (route.path === '/v1/:key/report') {
             app[method](route.path, parse({ type: '' }), handler);
           } else {

--- a/packages/trackx-api/src/routes/v1/[key]/event.ts
+++ b/packages/trackx-api/src/routes/v1/[key]/event.ts
@@ -445,11 +445,11 @@ export const post: Middleware = (req, res, next) => {
     }
 
     // TODO: More/better validation of meta data
-    // TODO: 128_000 is a magic number; should be configurable or improve calculation
+    // TODO: Should there be a separate config option rather than MAX_EVENT_BYTES?
     if (meta !== undefined) {
       if (
         Object.prototype.toString.call(meta) !== '[object Object]'
-        || JSON.stringify(meta).length > 128_000
+        || JSON.stringify(meta).length > config.MAX_EVENT_BYTES
       ) {
         throw new AppError('Invalid meta', Status.UNPROCESSABLE_ENTITY);
       }


### PR DESCRIPTION
Previously incoming event data size was limited to 100KiB due to `@polka/parse` default. The event meta data was also arbitrarily limited.

Both of those limits are now set to the user config value for `MAX_EVENT_BYTES`. In future we may use a seperate config key/s.