### PR TITLE
chore: Move *.xcss unnamed imports as first import in seperate group

### DIFF
--- a/packages/trackx-dash/src/App.tsx
+++ b/packages/trackx-dash/src/App.tsx
@@ -1,3 +1,5 @@
+import './css/index.xcss';
+
 import { Route, Router, routeTo } from '@maxmilton/solid-router';
 import { JSX, lazy } from 'solid-js';
 import { ErrorBoundary, Suspense } from 'solid-js/web';
@@ -5,7 +7,6 @@ import { Debug } from './components/Debug';
 import { Footer } from './components/Footer';
 import { Loading } from './components/Loading';
 import { Nav } from './components/Nav';
-import './css/index.xcss';
 import { ErrorPage } from './pages/error';
 import { AppError } from './utils';
 

--- a/packages/trackx-dash/src/components/CodeBlock.tsx
+++ b/packages/trackx-dash/src/components/CodeBlock.tsx
@@ -1,6 +1,7 @@
+import './CodeBlock.xcss';
+
 import { IconCopy } from '@trackx/icons/src';
 import { createSignal, type FlowComponent } from 'solid-js';
-import './CodeBlock.xcss';
 
 export const CodeBlock: FlowComponent = (props) => {
   const [copied, setCopied] = createSignal();

--- a/packages/trackx-dash/src/components/Debug/Debug.tsx
+++ b/packages/trackx-dash/src/components/Debug/Debug.tsx
@@ -1,6 +1,7 @@
+import './Debug.xcss';
+
 import { onMount, type Component } from 'solid-js';
 import { createStore } from 'solid-js/store';
-import './Debug.xcss';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/trackx-dash/src/components/Dialog.tsx
+++ b/packages/trackx-dash/src/components/Dialog.tsx
@@ -1,5 +1,6 @@
-import { onCleanup, onMount, type FlowComponent } from 'solid-js';
 import './Dialog.xcss';
+
+import { onCleanup, onMount, type FlowComponent } from 'solid-js';
 
 interface DialogProps {
   onClose: () => void;

--- a/packages/trackx-dash/src/components/Footer.tsx
+++ b/packages/trackx-dash/src/components/Footer.tsx
@@ -1,5 +1,6 @@
-import type { Component } from 'solid-js';
 import './Footer.xcss';
+
+import type { Component } from 'solid-js';
 
 export const Footer: Component = () => (
   <footer class="footer">

--- a/packages/trackx-dash/src/components/Graph.tsx
+++ b/packages/trackx-dash/src/components/Graph.tsx
@@ -1,3 +1,5 @@
+import './Graph.xcss';
+
 import {
   createEffect,
   createResource,
@@ -10,7 +12,6 @@ import UPlot from 'uplot';
 import type { TimeSeriesData } from '../../../trackx-api/src/types';
 import { config, fetchJSON } from '../utils';
 import { renderErrorAlert } from './ErrorAlert';
-import './Graph.xcss';
 import { Loading } from './Loading';
 
 type PartialLike<T> = {

--- a/packages/trackx-dash/src/components/Nav.tsx
+++ b/packages/trackx-dash/src/components/Nav.tsx
@@ -1,9 +1,10 @@
+import './Nav.xcss';
+
 import { NavLink } from '@maxmilton/solid-router';
 import { IconDotsVertical } from '@trackx/icons';
 import { createSignal, type Component } from 'solid-js';
 import { Show } from 'solid-js/web';
 import { logout } from '../utils';
-import './Nav.xcss';
 
 export const Nav: Component = () => {
   const [showSubnav, setShowSubnav] = createSignal(false);

--- a/packages/trackx-dash/src/components/StackTrace.tsx
+++ b/packages/trackx-dash/src/components/StackTrace.tsx
@@ -1,9 +1,10 @@
+import './StackTrace.xcss';
+
 // import { IconChevronDown, IconExternalLink } from '@trackx/icons';
 import { IconChevronDown } from '@trackx/icons';
 import { createSignal, type Component } from 'solid-js';
 import { For, Show } from 'solid-js/web';
 // import { isValidURL } from '../utils';
-import './StackTrace.xcss';
 
 // TODO: Types like this which are shared across packages should be in one
 // place, a type source of truth to make sure they're up-to-date

--- a/packages/trackx-dash/src/components/Tabs.tsx
+++ b/packages/trackx-dash/src/components/Tabs.tsx
@@ -1,3 +1,5 @@
+import './Tabs.xcss';
+
 import {
   createSignal,
   type Accessor,
@@ -6,7 +8,6 @@ import {
   type Setter,
 } from 'solid-js';
 import { Match, Switch } from 'solid-js/web';
-import './Tabs.xcss';
 
 interface TabsProps {
   children: JSX.Element[];

--- a/packages/trackx-dash/src/pages/issues/[id].tsx
+++ b/packages/trackx-dash/src/pages/issues/[id].tsx
@@ -1,5 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 
+import './[id].xcss';
+
 import {
   routeTo,
   useURLParams,
@@ -25,7 +27,6 @@ import { StackTrace } from '../../components/StackTrace';
 import {
   AppError, config, fetchJSON, logout,
 } from '../../utils';
-import './[id].xcss';
 
 // Matches equivalent client enum in packages/trackx/types.ts
 const EventType = {

--- a/packages/trackx-dash/src/pages/issues/index.tsx
+++ b/packages/trackx-dash/src/pages/issues/index.tsx
@@ -1,3 +1,5 @@
+import './index.xcss';
+
 import { useURLParams, type RouteComponent } from '@maxmilton/solid-router';
 import { IconChevronRight, IconSearch, IconX } from '@trackx/icons';
 import reltime from '@trackx/reltime';
@@ -10,7 +12,6 @@ import type { Issue } from '../../../../trackx-api/src/types';
 import { renderErrorAlert } from '../../components/ErrorAlert';
 import { Loading } from '../../components/Loading';
 import { compactNumber, config, fetchJSON } from '../../utils';
-import './index.xcss';
 
 const RESULT_LIMIT = 25;
 

--- a/packages/trackx-dash/src/pages/logs.tsx
+++ b/packages/trackx-dash/src/pages/logs.tsx
@@ -1,3 +1,5 @@
+import './logs.xcss';
+
 import { IconChevronRight } from '@trackx/icons';
 import { createEffect, createResource, type Component } from 'solid-js';
 import { createStore } from 'solid-js/store';
@@ -6,7 +8,6 @@ import type { Logs } from '../../../trackx-api/src/types';
 import { renderErrorAlert } from '../components/ErrorAlert';
 import { Loading } from '../components/Loading';
 import { config, fetchJSON } from '../utils';
-import './logs.xcss';
 
 interface PaginatedTableProps {
   headers: string[];

--- a/packages/trackx-dash/src/pages/projects/[name]/index.tsx
+++ b/packages/trackx-dash/src/pages/projects/[name]/index.tsx
@@ -1,3 +1,5 @@
+import './index.xcss';
+
 import { useURLParams, type RouteComponent } from '@maxmilton/solid-router';
 import { IconChevronRight, IconHelp } from '@trackx/icons';
 import reltime from '@trackx/reltime';
@@ -18,7 +20,6 @@ import { renderErrorAlert } from '../../../components/ErrorAlert';
 import { Graph } from '../../../components/Graph';
 import { Loading } from '../../../components/Loading';
 import { compactNumber, config, fetchJSON } from '../../../utils';
-import './index.xcss';
 
 interface SessionPeriodInfoProps {
   data: SessionsData['period'];

--- a/packages/trackx-dash/src/pages/projects/index.tsx
+++ b/packages/trackx-dash/src/pages/projects/index.tsx
@@ -1,3 +1,5 @@
+import './index.xcss';
+
 import { IconSearch, IconX } from '@trackx/icons';
 import {
   createEffect,
@@ -10,7 +12,6 @@ import type { ProjectList } from '../../../../trackx-api/src/types';
 import { renderErrorAlert } from '../../components/ErrorAlert';
 import { Loading } from '../../components/Loading';
 import { compactNumber, config, fetchJSON } from '../../utils';
-import './index.xcss';
 
 const ProjectsPage: Component = () => {
   let list: ProjectList;

--- a/packages/trackx-dash/src/pages/stats.tsx
+++ b/packages/trackx-dash/src/pages/stats.tsx
@@ -1,3 +1,5 @@
+import './stats.xcss';
+
 import reltime from '@trackx/reltime';
 import { createEffect, createResource, type Component } from 'solid-js';
 import { For, Match, Switch } from 'solid-js/web';
@@ -7,7 +9,6 @@ import { renderErrorAlert } from '../components/ErrorAlert';
 import { Graph } from '../components/Graph';
 import { Loading } from '../components/Loading';
 import { config, fetchJSON } from '../utils';
-import './stats.xcss';
 
 interface DailyGraphProps {
   data: TimeSeriesData;

--- a/packages/trackx-dash/src/pages/test.tsx
+++ b/packages/trackx-dash/src/pages/test.tsx
@@ -1,12 +1,13 @@
 // eslint-disable-next-line max-len
 /* eslint-disable @typescript-eslint/no-floating-promises, @typescript-eslint/no-misused-promises, @typescript-eslint/no-throw-literal, func-names, no-console, no-await-in-loop, no-plusplus, max-classes-per-file, jsx-a11y/anchor-is-valid, unicorn/error-message, unicorn/no-array-for-each */
 
+import './test.xcss';
+
 import { createEffect, type Component } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import { For } from 'solid-js/web';
 import { Loading } from '../components/Loading';
 import { adHocQuery, AppError, config } from '../utils';
-import './test.xcss';
 
 class CustomError extends Error {
   declare code: number | undefined;

--- a/packages/trackx-login/src/index.ts
+++ b/packages/trackx-login/src/index.ts
@@ -1,7 +1,8 @@
 /* eslint-disable prefer-template */
 
-import * as config from '../../trackx-dash/trackx.config.mjs';
 import './index.xcss';
+
+import * as config from '../../trackx-dash/trackx.config.mjs';
 import {
   append, create, dirty, getElement,
 } from './utils';


### PR DESCRIPTION
Since VS Code version 1.68 the `sortImports` feature now supports seperate "import groups". So we can now split XCSS file imports into a seperate group and move it to the first import to ensure component parent styles come before child styles.