### PR TITLE
bug(trackx-cli): Fix output so hashbang is first

### DIFF
--- a/packages/trackx-cli/tsconfig.json
+++ b/packages/trackx-cli/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "module": "commonjs"
+    "module": "commonjs",
+    "alwaysStrict": false
   }
 }


### PR DESCRIPTION
Since a recent esbuild update, it automatically injects `"use strict";` when `tsconfig.json` contains `"alwaysStrict": true`. We need to disable that feature because our file needs a hashbang at the top.