### PR TITLE
chore: Add eslint security plugin

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,9 +2,6 @@ const OFF = 0;
 const WARN = 1;
 const ERROR = 2;
 
-// TODO: Types
-// eslint-disable-next-line max-len
-// /** @type {import('eslint/lib/shared/types').ConfigData & { parserOptions: import('@typescript-eslint/types').ParserOptions }} */
 module.exports = {
   root: true,
   reportUnusedDisableDirectives: true,
@@ -21,6 +18,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:unicorn/recommended',
+    'plugin:security/recommended',
   ],
   settings: {
     'import/resolver': {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "26.5.3",
     "eslint-plugin-jsx-a11y": "6.6.0",
+    "eslint-plugin-security": "1.5.0",
     "eslint-plugin-unicorn": "42.0.0",
     "jest": "28.1.1",
     "jest-environment-jsdom": "28.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ importers:
       eslint-plugin-import: 2.26.0
       eslint-plugin-jest: 26.5.3
       eslint-plugin-jsx-a11y: 6.6.0
+      eslint-plugin-security: 1.5.0
       eslint-plugin-unicorn: 42.0.0
       jest: 28.1.1
       jest-environment-jsdom: 28.1.1
@@ -59,6 +60,7 @@ importers:
       eslint-plugin-import: 2.26.0_zgg5sxdhnxsuz2d3vdnwdtmcnu
       eslint-plugin-jest: 26.5.3_ed7rxttb2wpk7audeky7cybyim
       eslint-plugin-jsx-a11y: 6.6.0_eslint@8.18.0
+      eslint-plugin-security: 1.5.0
       eslint-plugin-unicorn: 42.0.0_eslint@8.18.0
       jest: 28.1.1_@types+node@18.0.0
       jest-environment-jsdom: 28.1.1
@@ -3051,6 +3053,12 @@ packages:
       language-tags: 1.0.5
       minimatch: 3.1.2
       semver: 6.3.0
+    dev: true
+
+  /eslint-plugin-security/1.5.0:
+    resolution: {integrity: sha512-hAFVwLZ/UeXrlyVD2TDarv/x00CoFVpaY0IUZhKjPjiFxqkuQVixsK4f2rxngeQOqSxi6OUjzJM/jMwKEVjJ8g==}
+    dependencies:
+      safe-regex: 2.1.1
     dev: true
 
   /eslint-plugin-unicorn/42.0.0_eslint@8.18.0:


### PR DESCRIPTION
Even though there are many false positives or misses, `eslint-plugin-security` is still helpful. Even if only to be reminded about defensive programming.