### PR TITLE
bug(trackx-api): Update docker image

### DIFF
--- a/.github/workflows/test-docker.sh
+++ b/.github/workflows/test-docker.sh
@@ -18,7 +18,7 @@ docker run --rm \
   --security-opt no-new-privileges \
   --env CONFIG_PATH="/data/trackx.config.js" \
   --env DB_PATH="/tmp/db/trackx.db" \
-  --tmpfs /tmp/db:rw,noexec,nodev,nosuid,uid=5063,gid=5063,mode=0700,size=10m \
+  --tmpfs /tmp/db:rw,noexec,nodev,nosuid,uid=506,gid=506,mode=0700,size=10m \
   --mount type=bind,src="$config_path",dst=/data/trackx.config.js,ro \
   --mount type=bind,src="${repo_root_dir}/packages/trackx-api/migrations/master.sql",dst=/data/db/master.sql \
   ci/trackx-api /usr/bin/node cli.js install

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -59,7 +59,7 @@ TODO: Simplify and refine install process.
    1. Edit `/opt/trackx/etc/nginx/conf.d/dash.trackx.app.conf`
 1. <span class="tag">SERVER</span> Set file ownership:
    ```sh
-   sudo chown -R 5063:5063 /opt/trackx && sudo chown -R root:root /opt/trackx/etc/nginx && sudo chmod 400 /opt/trackx/etc/nginx/certs/*
+   sudo chown -R 506:506 /opt/trackx && sudo chown -R root:root /opt/trackx/etc/nginx && sudo chmod 400 /opt/trackx/etc/nginx/certs/*
    ```
 1. Deploy the Docker images to your server:
    ```sh

--- a/packages/trackx-api/Dockerfile
+++ b/packages/trackx-api/Dockerfile
@@ -38,8 +38,8 @@ RUN set -xe \
 FROM debian:bullseye-slim@sha256:67f5a66b7d31a1eb725271b7f02f3128aade7ea1f675978fb09ba00cb4a5a980
 ENV NODE_ENV production
 RUN set -xe \
-  && groupadd -g 5063 -r nodejs \
-  && useradd -r -u 5063 -M -s /sbin/nologin -g nodejs nodejs
+  && groupadd -g 506 -r nodejs \
+  && useradd -r -u 506 -M -s /sbin/nologin -g nodejs nodejs
 WORKDIR /data/
 COPY --from=install_deps --chown=nodejs:nodejs /data/ /data/
 COPY --from=install_deps /usr/bin/node /usr/bin/node

--- a/packages/trackx-api/Dockerfile
+++ b/packages/trackx-api/Dockerfile
@@ -1,7 +1,7 @@
 # Install NPM modules including building node-gyp binaries e.g., better-sqlite3
 FROM debian:bullseye-slim@sha256:67f5a66b7d31a1eb725271b7f02f3128aade7ea1f675978fb09ba00cb4a5a980 AS install_deps
-ENV SQLITE_TOOLS_URL https://www.sqlite.org/2022/sqlite-tools-linux-x86-3380500.zip
-ENV SQLITE_TOOLS_SHA3 42a62a0914967cdd9ba6e409750744da5a4cd03a34cbd3208fe8443523fdfacc
+ENV SQLITE_TOOLS_URL https://www.sqlite.org/2022/sqlite-tools-linux-x86-3390000.zip
+ENV SQLITE_TOOLS_SHA3 cf29e7956267045cae8f18e0018a3d8d50765032c6222d673d0edd894a982637
 RUN set -xe \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/packages/trackx-api/Dockerfile
+++ b/packages/trackx-api/Dockerfile
@@ -47,8 +47,8 @@ COPY --from=install_deps /sqlite3 /usr/bin/sqlite3
 # Fustratingly, SQLite don't provide official 64-bit precompiled binaries so we
 # need to add 32-bit C libs to run their 32-bit binary
 COPY --from=install_deps /lib/ld-linux.so.2 /lib/ld-linux.so.2
-COPY --from=install_deps /lib32/libdl-2.31.so /lib32/libdl.so.2
-COPY --from=install_deps /lib32/libm-2.31.so /lib32/libm.so.6
-COPY --from=install_deps /lib32/libc-2.31.so /lib32/libc.so.6
+COPY --from=install_deps /lib32/libdl-2.33.so /lib32/libdl.so.2
+COPY --from=install_deps /lib32/libm-2.33.so /lib32/libm.so.6
+COPY --from=install_deps /lib32/libc-2.33.so /lib32/libc.so.6
 USER nodejs:nodejs
 CMD ["/usr/bin/node", "--report-on-fatalerror", "server.js"]

--- a/scripts/trackx
+++ b/scripts/trackx
@@ -9,8 +9,8 @@ TRACKX_DB_DIR=/opt/trackx/var/db
 DOCKER_IMAGE=trackx-api
 
 test -d "$TRACKX_DB_DIR" || mkdir -p "$TRACKX_DB_DIR"
-test "$(stat -c '%u' "$TRACKX_DB_DIR")" = "5063" || sudo chown 5063:5063 "$TRACKX_DB_DIR"
-test "$(stat -c '%u' "$CONFIG_PATH")" = "5063" || sudo chown 5063:5063 "$CONFIG_PATH"
+test "$(stat -c '%u' "$TRACKX_DB_DIR")" = "506" || sudo chown 506:506 "$TRACKX_DB_DIR"
+test "$(stat -c '%u' "$CONFIG_PATH")" = "506" || sudo chown 506:506 "$CONFIG_PATH"
 
 docker run \
   --rm \


### PR DESCRIPTION
- Set docker user uid to a valid system user number
  - Turns out system user accounts should be between 101 and 999.  `useradd` will show a warning otherwise.
- Update version of sqlite bins
- Update system lib paths