### PR TITLE
feat: Refactor stats

### DIFF
--- a/packages/trackx-api/src/types.ts
+++ b/packages/trackx-api/src/types.ts
@@ -148,12 +148,18 @@ export interface TrackXAPIConfig {
    */
   readonly SESSION_TTL: number;
 
+  // TODO: Consider moving DB table stats to trackx-cli
   /**
-   * Show database table size statistics on the dash `/stats` page.
+   * Allow fetching database table statistics via the `api/dash/stats?type=db`
+   * API route. Used on the `trackx-dash` `/stats` page.
+   *
+   * Note that there's also a matching config option in `trackx-dash` that should
+   * also be set to the same value.
    *
    * @remarks Currently has known performance issues. Enabling this feature may
    * be useful for debugging and observability but should be disabled in
-   * production to prevent a potential denial-of-service attack vector.
+   * production to prevent a potential denial-of-service attack vector. See
+   * <https://github.com/maxmilton/trackx/issues/158>.
    */
   readonly ENABLE_DB_TABLE_STATS?: boolean;
 }
@@ -315,8 +321,6 @@ export interface SessionsData {
   period: [current: SessionsCount, previous: SessionsCount];
 }
 
-export type StatsDBTableInfo = [name: string, size: string, percent: string];
-
 export interface Stats {
   session_c: number;
   session_e_c: number;
@@ -334,10 +338,19 @@ export interface Stats {
   api_v: string;
   api_uptime: number;
   dash_session_c: number;
+}
+
+export type DBStatsTable = {
+  name: string;
+  size: string;
+  percent: string;
+};
+
+/** @remarks Only available when config flag "ENABLE_DB_TABLE_STATS" is true. */
+export interface DBStats {
   db_size: string;
-  dbwal_size: string;
-  // Optional because it's behind the config flag "ENABLE_DB_TABLE_STATS"
-  db_tables?: StatsDBTableInfo[];
+  db_size_wal: string;
+  db_tables: DBStatsTable[];
 }
 
 export interface Logs {

--- a/packages/trackx-dash/rollup.config.js
+++ b/packages/trackx-dash/rollup.config.js
@@ -15,6 +15,7 @@ import esbuild from 'rollup-plugin-esbuild';
 import { terser } from 'rollup-plugin-terser';
 import { visualizer } from 'rollup-plugin-visualizer';
 import pkg from './package.json';
+import * as config from './trackx.config.mjs';
 
 const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
@@ -51,6 +52,7 @@ const terserOpts = {
     wrap_iife: true,
     wrap_func_args: true,
   },
+  // mangle: false,
 };
 
 /** @type {import('rollup').WatcherOptions} */
@@ -138,6 +140,7 @@ export default [
     plugins: [
       replace({
         'process.env.APP_RELEASE': JSON.stringify(release),
+        'process.env.ENABLE_DB_TABLE_STATS': !!config.ENABLE_DB_TABLE_STATS,
         'process.env.NODE_ENV': JSON.stringify(mode),
         'process.env.XCSS_GLOBALS': JSON.stringify(
           // eslint-disable-next-line

--- a/packages/trackx-dash/trackx.config.mjs
+++ b/packages/trackx-dash/trackx.config.mjs
@@ -1,4 +1,10 @@
-// TrackX configuration for frontends
+/**
+ * TrackX configuration for front end apps (trackx-dash and trackx-login).
+ *
+ * @fileoverview The configuration values in this file will be compiled into
+ * the apps. Because this values will become hardcoded, when you change a value
+ * you will need to rebuild and deploy the front end apps.
+ */
 
 const prod = process.env.NODE_ENV === 'production' || !process.env.NODE_ENV;
 
@@ -10,3 +16,17 @@ export const REPORT_API_BASE_URL = prod
   ? 'https://api.trackx.app/v1'
   : '/api/v1';
 export const REPORT_API_KEY = '1dncxc0jjib';
+
+// TODO: Consider moving DB table stats to trackx-cli
+/**
+ * Enable fetching database stats.
+ *
+ * Note there is also a `ENABLE_DB_TABLE_STATS` config option in `trackx-api`
+ * that should also be set to the same value.
+ *
+ * @remarks Currently has known performance issues. Enabling this feature may
+ * be useful for debugging and observability but should be disabled in
+ * production to prevent a potential denial-of-service attack vector. See
+ * <https://github.com/maxmilton/trackx/issues/158>.
+ */
+export const ENABLE_DB_TABLE_STATS = true;


### PR DESCRIPTION
- Move database stats into a seperate API call.
- Also show number of daily denied dash requests.
- `trackx-api`: Greatly simplify the database table stats logic. Instead of getting the page size of explisitly named tables, it now just shows all tables in the database.
  - `issue_fts*` tables are no longer grouped together but it's not particuarly a problem.
- `trackx-dash`: Add new frontend config option to enable/disable database stats (required in addition to server config option).
  - When `ENABLE_DB_TABLE_STATS` is `false`, the entire DB stats logic is removed from the output stats page JS bundle.
- `trackx-dash`: Adjust `/stats` page layout; text stats on left, graphs on right.
- `trackx-dash`:  Getting database stats now requires a user interaction via a button.
  - Get the general stats should be much much faster while still providing database table stats for debugging.
  - Also show a simple warning in the UI.