### PR TITLE
feat: Add project select to issues page

### DIFF
--- a/packages/trackx-api/src/index.ts
+++ b/packages/trackx-api/src/index.ts
@@ -69,7 +69,7 @@ process.on('SIGTERM', () => handleExit(() => process.exit(128 + 15)));
 
 const dash: Middleware = (_req, _res, next) => {
   void next();
-  incrementDailyDash();
+  setTimeout(incrementDailyDash, 30);
 };
 
 app.use(log);

--- a/packages/trackx-api/src/types.ts
+++ b/packages/trackx-api/src/types.ts
@@ -211,6 +211,8 @@ export type ProjectList = {
   session_c: number | null;
 }[];
 
+export type ProjectListSimple = string[];
+
 export interface ProjectOverview {
   issues: Issue[];
   uris: Array<{

--- a/packages/trackx-dash/src/pages/test.tsx
+++ b/packages/trackx-dash/src/pages/test.tsx
@@ -435,7 +435,7 @@ export const TestPage: RouteComponent = () => {
               document.open();
               document.write('<h1>Test</h1>');
               document.close();
-            } catch (error) {
+            } catch (error: unknown) {
               console.warn(error);
             }
           }}
@@ -1817,16 +1817,16 @@ DROP TRIGGER tmp_session_ai;`,
       <h3 id="ui-components">UI components</h3>
 
       <div class="alert alert-info">
-        <strong>TIP:</strong> Example info alert.
+        <strong>ALERT:</strong> Example info alert.
       </div>
       <div class="alert alert-success">
-        <strong>TIP:</strong> Example success alert.
+        <strong>ALERT:</strong> Example success alert.
       </div>
       <div class="alert alert-warning">
-        <strong>TIP:</strong> Example warning alert.
+        <strong>ALERT:</strong> Example warning alert.
       </div>
       <div class="alert alert-danger">
-        <strong>TIP:</strong> Example danger alert.
+        <strong>ALERT:</strong> Example danger alert.
       </div>
 
       <div class="mb3">


### PR DESCRIPTION
- `trackx-api`: Add new route option to get simple project name list
- `trackx-api`: Defer `incrementDailyDash` so it doesn't slow down batches of requests (since writes lock the DB)
- `trackx-dash`: Add select dropdown to issues page for selecting a project
- `trackx-dash`: Minor clean up of issues list page
  - Improve initial state logic
- `trackx-dash`: Fix lingering error alert message even after changing sort/project