### PR TITLE
bug(trackx-api): Don't compute in DB transaction

### DIFF
--- a/packages/trackx-api/src/routes/dash/issue/[issueId]/event/[eventId].ts
+++ b/packages/trackx-api/src/routes/dash/issue/[issueId]/event/[eventId].ts
@@ -13,7 +13,12 @@ import {
 const VALID_DIR_VALUES = ['first', 'prev', 'next', 'last'];
 
 const getIssueEventFirstStmt = db.prepare(`
-  SELECT id, ts, type, data, 1 AS is_first
+  SELECT
+    id,
+    ts,
+    type,
+    data,
+    1 AS is_first
   FROM event
   WHERE issue_id = @issueId
   ORDER BY id


### PR DESCRIPTION
- Move stats data computation out of database transaction
- Tweak stats `remapGraphData` function for efficiency
- Tweak DB query whitespace for consistency