### PR TITLE
bug(trackx-dash): Highlight only the active tab

### DIFF
--- a/packages/trackx-dash/src/components/Tabs.tsx
+++ b/packages/trackx-dash/src/components/Tabs.tsx
@@ -43,9 +43,10 @@ export const Tabs: Component<TabsProps> = (props) => {
     <div class="tabs">
       <div role="tablist">
         {props.titles.map((title, index) => (
+          // @ts-expect-error - FIXME: aria-selected should take undefined|null
           <button
             role="tab"
-            aria-selected={currentTab() === index}
+            aria-selected={currentTab() === index || undefined}
             onClick={() => setCurrentTab(index)}
             textContent={title}
           />

--- a/packages/trackx-dash/src/pages/projects/[name]/install.tsx
+++ b/packages/trackx-dash/src/pages/projects/[name]/install.tsx
@@ -9,6 +9,15 @@ import { Loading } from '../../../components/Loading';
 import { Tabs } from '../../../components/Tabs';
 import { config, fetchJSON } from '../../../utils';
 
+// FIXME: Rework this page.
+//  ↳ A high percent of the time users want the tracking + ping snippet, so
+//    that should be at the top.
+//  ↳ Simplify what's shown by default. Maybe have a "expand" button that will
+//    show more detailed instructions. Or maybe link to the docs which should
+//    have fully detailed instructions.
+//  ↳ Something like a "quick start guide" and "advanced" sections.
+//  ↳ It should probably at least mention the various clients.
+
 const ProjectInstallPage: RouteComponent = (props) => {
   const [project] = createResource<Project, string>(
     () => `${config.DASH_API_ENDPOINT}/project/${props.params.name}`,


### PR DESCRIPTION
After changes to the way Solid handles `false` values in element attributes, the Tabs `aria-selected` attribute needs to be set to `undefined` rather than `false`.