### PR TITLE
feat(trackx-dash): Refactor build for optimised bundles

### DIFF
--- a/packages/trackx-dash/rollup.config.js
+++ b/packages/trackx-dash/rollup.config.js
@@ -17,6 +17,7 @@ const { visualizer } = require('rollup-plugin-visualizer');
 const pkg = require('./package.json');
 const xcssConfig = require('./xcss.config.cjs');
 
+const viz = !!process.env.BUNDLE_VIZ;
 const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
 const release = `v${pkg.version}-${gitHash()}${isDirty() ? '-dev' : ''}`;
@@ -115,7 +116,7 @@ const htmlTemplate = ({
     .replace(/\n\s+/g, '\n'); // remove leading whitespace
 };
 
-/** @type {import('rollup').RollupOptions[]} */
+/** @type {()=>Promise< import('rollup').RollupOptions[]>} */
 module.exports = async () => [
   // Error tracking
   {
@@ -224,8 +225,7 @@ module.exports = async () => [
         // @ts-expect-error - bad upstream types
         template: htmlTemplate,
       }),
-      process.env.BUNDLE_VIZ
-        && visualizer({ filename: 'dist/viz.html', brotliSize: true }),
+      viz && visualizer({ filename: 'dist/viz.html', brotliSize: true }),
     ],
     watch,
   },

--- a/packages/trackx-dash/src/utils.ts
+++ b/packages/trackx-dash/src/utils.ts
@@ -1,3 +1,7 @@
+// TODO: If we add more utils, split this file up to prevent everything getting
+// bundled into the app.js entry file (which should be as small as possible; it
+// should only check the session then redirect or load the app).
+
 import * as config from '../trackx.config.mjs';
 
 export * as config from '../trackx.config.mjs';

--- a/packages/trackx-login/package.json
+++ b/packages/trackx-login/package.json
@@ -22,6 +22,7 @@
     "lightningcss": "1.16.0",
     "purgecss": "5.0.0",
     "terser": "5.15.1",
+    "totalist": "3.0.0",
     "trackx-dash": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,7 @@ importers:
       lightningcss: 1.16.0
       purgecss: 5.0.0
       terser: 5.15.1
+      totalist: 3.0.0
       trackx-dash: workspace:*
     dependencies:
       '@ekscss/framework': 0.0.42_ekscss@0.0.13
@@ -271,6 +272,7 @@ importers:
       lightningcss: 1.16.0
       purgecss: 5.0.0
       terser: 5.15.1
+      totalist: 3.0.0
       trackx-dash: link:../trackx-dash
 
 packages:


### PR DESCRIPTION
- Make entry JS file self-contained; now it doesn't need to fetch any other files.
- Force all non-page content JS code into a single "runtime" bundle.
- Add cache busting hash to trackx JS bundle.
  - Use new bundle name in place of git commit hash as cache busting.
  - Set up both the dash and login apps.
- Minor minification improvement.
