### PR TITLE
bug(trackx-cli): Match `better-sqlite3` version

### DIFF
--- a/packages/trackx-cli/package.json
+++ b/packages/trackx-cli/package.json
@@ -19,7 +19,7 @@
     "trackx": "NODE_ENV=development node -r source-map-support/register ./dist/cli.js --config ../trackx-api/trackx.config.js"
   },
   "dependencies": {
-    "better-sqlite3": "8.0.1",
+    "better-sqlite3": "7.6.2",
     "kleur": "4.1.5",
     "punycode": "2.3.0",
     "sade": "1.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,7 +175,7 @@ importers:
     specifiers:
       '@types/better-sqlite3': 7.6.3
       '@types/punycode': 2.1.0
-      better-sqlite3: 8.0.1
+      better-sqlite3: 7.6.2
       git-ref: 0.3.1
       kleur: 4.1.5
       mri: 1.2.0
@@ -183,7 +183,7 @@ importers:
       sade: 1.8.1
       source-map-support: 0.5.21
     dependencies:
-      better-sqlite3: 8.0.1
+      better-sqlite3: 7.6.2
       kleur: 4.1.5
       punycode: 2.3.0
       sade: 1.8.1
@@ -2317,14 +2317,6 @@ packages:
 
   /better-sqlite3/7.6.2:
     resolution: {integrity: sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.1
-    dev: false
-
-  /better-sqlite3/8.0.1:
-    resolution: {integrity: sha512-JhTZjpyapA1icCEjIZB4TSSgkGdFgpWZA2Wszg7Cf4JwJwKQmbvuNnJBeR+EYG/Z29OXvR4G//Rbg31BW/Z7Yg==}
     requiresBuild: true
     dependencies:
       bindings: 1.5.0


### PR DESCRIPTION
`better-sqlite3` version should be same across both `trackx-api` and `trackx-cli`.